### PR TITLE
support namespace label selection

### DIFF
--- a/utilslib/dr.py
+++ b/utilslib/dr.py
@@ -296,11 +296,10 @@ class K8s(object):
     @lib.timing_wrapper
     @lib.k8s_chunk_wrapper
     @lib.retry_wrapper
-    def list_namespaces(self, **kwargs):
-        if 'next' in kwargs:
-            kwargs['_continue'] = kwargs['next']
-            del kwargs['next']
-        return self.v1.list_namespace(**kwargs)
+    def list_namespaces(self, limit=100, next='', label_selector=''):
+        return self.v1.list_namespace(limit=limit, _continue=next, 
+                                      label_selector=label_selector)
+
 
     @lib.timing_wrapper
     @lib.retry_wrapper

--- a/utilslib/dr.py
+++ b/utilslib/dr.py
@@ -296,8 +296,11 @@ class K8s(object):
     @lib.timing_wrapper
     @lib.k8s_chunk_wrapper
     @lib.retry_wrapper
-    def list_namespaces(self, limit=100, next=''):
-        return self.v1.list_namespace(limit=limit, _continue=next)
+    def list_namespaces(self, **kwargs):
+        if 'next' in kwargs:
+            kwargs['_continue'] = kwargs['next']
+            del kwargs['next']
+        return self.v1.list_namespace(**kwargs)
 
     @lib.timing_wrapper
     @lib.retry_wrapper


### PR DESCRIPTION
This patch changes list_namespaces to accept a label selector parameter so the periodic backup pod can select namespaces by label